### PR TITLE
SKIP-123: change action runtime to NodeJS v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: "A regex pattern to check if a pull request title is valid."
     required: true
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Fix for the deprecation warning
<img width="973" alt="image" src="https://user-images.githubusercontent.com/1327380/196115192-9c59e857-9993-4bff-8c51-ffa47df6565b.png">
